### PR TITLE
Array init fix

### DIFF
--- a/algo1.py
+++ b/algo1.py
@@ -32,10 +32,7 @@ class Array:
                         self.size=0
                 else:
                         self.size=size
-                if type(init_value)!=Array:
-                    self.data= [copy.deepcopy(None) for i in range(0,size)]
-                else:
-                    self.data= [copy.deepcopy(init_value) for i in range(0,size)]
+                self.data= [copy.deepcopy(init_value) for i in range(0,size)]
                 self.type = type(init_value)
         def __getitem__(self,index):
                 if index > self.size:


### PR DESCRIPTION
Hola profe, como anda

Estaba viendo que en el constructor de la clase Array, hay un parámetro llamado `init_value`.
Yo entendí que seria el valor con el que todo el Array se inicializa, pero en realidad cuando lo probé :
```py
str(Array(2,3))
```
Produce `[None, None]` ya que https://github.com/harpomaxx/algo-uno/blob/2b105ab5eec208728a36653b51839e54cafd113b/algo1.py#L36 copia `None`

Como me parecía que no era la intención original arme un PR con el cambio que propongo
Mi experiencia con Git y GitHub es bastante limitada de modo que espero haberlo hecho bien :), si no seguí alguna convención por favor indíqueme, gracias.

Si no era el caso, no hay problema y simplemente rechace el PR.
También lo quería tomar como oportunidad para investigar sobre GitHub. 

Saludos, Federico Williamson